### PR TITLE
use restart_process extension instead of restart_container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ api/*/*.pb.go
 .*.swp
 .*.swx
 
+tilt_modules

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ api/*/*.pb.go
 # vim temp files
 .*.swp
 .*.swx
-
-tilt_modules

--- a/Tiltfile
+++ b/Tiltfile
@@ -8,9 +8,10 @@
   * Language: JavaScript
   * Other notes: Uses yarn. Does a `yarn install` for package dependencies iff they have changed.
 * Numbers
-    * Language: Python
-    * Other notes: does a `pip install` for package dependencies. Reinstalls dependencies iff they have changed.
+  * Language: Python
+  * Other notes: does a `pip install` for package dependencies. Re-installs dependencies iff they have changed.
 """
+load('ext://restart_process', 'docker_build_with_restart')
 
 k8s_yaml([
     'fe/deployments/fe.yaml',
@@ -18,8 +19,8 @@ k8s_yaml([
     'numbers/deployments/numbers.yaml',
 ])
 
-# Port-forward your frontend so you can hit it locally -- you can access
-# the 'fe' service in your browser at http://localhost:8000
+# Port-forward services so you can hit it them locally -- e.g. you
+# can access the 'fe' service in your browser at http://localhost:8000
 k8s_resource('fe', port_forwards='8000')
 k8s_resource('letters', port_forwards='8001')
 k8s_resource('numbers', port_forwards='8002')
@@ -29,22 +30,21 @@ k8s_resource('numbers', port_forwards='8002')
 # See docs: https://docs.tilt.dev/live_update_tutorial.html
 
 # Service: fe
-docker_build('abc123/fe', 'fe',  # ~equivalent to: docker build -t abc123/fe ./fe
+docker_build_with_restart('abc123/fe', 'fe',  # ~equivalent to: docker build -t abc123/fe ./fe
+            '/go/bin/fe',
              live_update=[
                  sync('./fe', '/go/src/github.com/windmilleng/abc123/fe'),
                  run('go install github.com/windmilleng/abc123/fe'),
-                 restart_container()
              ])
 
 # Service: letters
-docker_build('abc123/letters', 'letters',
+docker_build_with_restart('abc123/letters', 'letters', 'node /app/index.js',
              live_update=[
                  sync('./letters/src', '/app'),
                  sync('./letters/package.json', '/app/package.json'),
                  sync('./letters/yarn.lock', '/app/yarn.lock'),
                  # run `yarn install` IF `package.json` or `yarn.lock` has changed
                  run('cd /app && yarn install', trigger=['./letters/package.json', './letters/yarn.lock']),
-                 restart_container(),
              ])
 
 # Service: numbers

--- a/tilt_modules/extensions.json
+++ b/tilt_modules/extensions.json
@@ -1,0 +1,22 @@
+{
+  "Extensions": [
+    {
+      "Name": "restart_process",
+      "GitCommitHash": "d0fc5e517421e44b35ee2938c8639c0ce0e315a2",
+      "ExtensionRegistry": "https://github.com/windmilleng/tilt-extensions",
+      "TimeFetched": "2020-04-23T18:23:43.824808-04:00"
+    },
+    {
+      "Name": "restart_process",
+      "GitCommitHash": "5951cea8f7fb8350473babdad56b73103d235234",
+      "ExtensionRegistry": "https://github.com/windmilleng/tilt-extensions",
+      "TimeFetched": "2020-04-28T17:35:03.406097-04:00"
+    },
+    {
+      "Name": "restart_process",
+      "GitCommitHash": "2158573741bc54bcd7e186b097e21f396e3d19b2",
+      "ExtensionRegistry": "https://github.com/windmilleng/tilt-extensions",
+      "TimeFetched": "2020-04-28T17:46:16.231477-04:00"
+    }
+  ]
+}

--- a/tilt_modules/restart_process/Tiltfile
+++ b/tilt_modules/restart_process/Tiltfile
@@ -1,0 +1,78 @@
+RESTART_FILE = '/.restart-proc'
+TYPE_RESTART_CONTAINER_STEP = 'live_update_restart_container_step'
+
+KWARGS_BLACKLIST = [
+    # since we'll be passing `dockerfile_contents` when building the
+    # child image, remove any kwargs that might conflict
+    'dockerfile', 'dockerfile_contents',
+
+    # 'target' isn't relevant to our child build--if we pass this arg,
+    # Docker will just fail to find the specified stage and error out
+    'target',
+]
+
+
+def docker_build_with_restart(ref, context, entrypoint, live_update,
+                              base_suffix='-base', restart_file=RESTART_FILE, **kwargs):
+    """Wrap a docker_build call and its associated live_update steps so that the last step
+    of any live update is to rerun the given entrypoint.
+
+
+     Args:
+      ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in docker_build
+      context: path to use as the Docker build context; as the parameter of the same name in docker_build
+      entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
+      live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
+      base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
+      restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      **kwargs: will be passed to the underlying `docker_build` call
+    """
+
+    # first, validate the given live_update steps
+    if len(live_update) == 0:
+        fail("`docker_build_with_restart` requires at least one live_update step")
+    for step in live_update:
+        if type(step) == TYPE_RESTART_CONTAINER_STEP:
+            fail("`docker_build_with_restart` is not compatible with live_update step: "+
+                 "`restart_container()` (this extension is meant to REPLACE restart_container() )")
+
+    # rename the original image to make it a base image and declare a docker_build for it
+    base_ref = '{}{}'.format(ref, base_suffix)
+    docker_build(base_ref, context, **kwargs)
+
+    # declare a new docker build that adds a static binary of tilt-restart-wrapper
+    # (which makes use of `entr` to watch files and restart processes) to the user's image
+    df = '''
+    FROM tiltdev/restart-helper:2020-04-27 as restart-helper
+
+    FROM {}
+    RUN ["touch", "{}"]
+    COPY --from=restart-helper /tilt-restart-wrapper /
+    COPY --from=restart-helper /entr /
+  '''.format(base_ref, restart_file)
+
+    # Clean kwargs for building the child image (which builds on user's specified
+    # image and copies in Tilt's restart wrapper). In practice, this means removing
+    # kwargs that were relevant to building the user's specified image but are NOT
+    # relevant to building the child image / may conflict with args we specifically
+    # pass for the child image.
+    cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
+
+    # Change the entrypoint to use `tilt-restart-wrapper`.
+    # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
+    # re-execute $entrypoint whenever $restart_file changes
+    if type(entrypoint) == type(""):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), "sh", "-c", entrypoint]
+    elif type(entrypoint) == type([]):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file)] + entrypoint
+    else:
+        fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
+
+    # last live_update step should always be to modify $restart_file, which
+    # triggers the process wrapper to rerun $entrypoint
+    # NB: write `date` instead of just `touch`ing because `entr` doesn't respond
+    # to timestamp changes, only writes (see https://github.com/eradman/entr/issues/32)
+    live_update = live_update + [run('date > {}'.format(restart_file))]
+
+    docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,
+                 live_update=live_update, **cleaned_kwargs)


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch with-restart-ext:

cbdab17bd02ff935188b7ee24f938ceba0249570 (2020-04-28 18:16:24 -0400)
use restart_process extension instead of restart_container

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics